### PR TITLE
Added command line options

### DIFF
--- a/scripts/newinstall.sh
+++ b/scripts/newinstall.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# **** This file should not be edited in place ****
+# It is maintained in a repository at
+# git@git.lsstcorp.org:LSST/DMS/devenv/lsst
+# 
+# If the file must be modified, clone the repository
+# and edit there.
+# *************************************************
 #
 # Bootstrap lsst stack install by:
 #   * Installing EUPS


### PR DESCRIPTION
Added 4 options;
-h -- prints help message
-b -- runs in batch mode so that no human interaction is necessary.
      It assumes that the answer would be yes to any question it would
      have asked
-f -- force install even in an non-empty directory
-P -- argument is the path to a valid python executable.  The use
      if $PYTHON is preserved, but overridden by this option.
