### PR TITLE
Fix failing loadLSST.zsh

### DIFF
--- a/scripts/newinstall.sh
+++ b/scripts/newinstall.sh
@@ -375,7 +375,7 @@ function generate_loader_zsh() {
 
 		# If not already initialized, set LSST_HOME to the directory where this script is located
 		if [[ -z \${LSST_HOME} ]]; then
-		   LSST_HOME="\$( cd "\$( dirname "\${0}" )" && pwd )"
+		   LSST_HOME=`dirname "$0:A"`
 		fi
 
 		# Bootstrap EUPS


### PR DESCRIPTION
While installing the LSST stack last week with @mjuric and @SimonKrughoff, I couldn't get the ``loadLSST.zsh`` script to work.  this fix got it to work for me.  I'm not sure if it's ZSH itself, the specific version I have, or the ``pwd`` that's in Mac OS X, but the current scheme yields special characters when you do ``cd`` followed by ``pwd``, so everything after was failing.  This change instead uses the ZSH idiom ``$0:A``, which gets the absolute path of the current file, and fixes the problem for me.