### PR TITLE
Don't reset the value of EUPS_PATH after bootstrapping EUPS

### DIFF
--- a/scripts/newinstall.sh
+++ b/scripts/newinstall.sh
@@ -337,7 +337,6 @@ function generate_loader_bash() {
 		# Bootstrap EUPS
 		EUPS_DIR="\${LSST_HOME}/eups"
 		source "\${EUPS_DIR}/bin/setups.sh"
-		EUPS_PATH="\${LSST_HOME}"
 
 		# Setup optional packages
 		$CMD_SETUP_ANACONDA
@@ -366,7 +365,6 @@ function generate_loader_csh() {
 		   # Bootstrap EUPS
 		   set EUPS_DIR = "\${LSST_HOME}/eups"
 		   source "\${EUPS_DIR}/bin/setups.csh"
-		   set EUPS_PATH = "\${LSST_HOME}"
 
 		   # Setup optional packages
 		   $CMD_SETUP_ANACONDA
@@ -392,7 +390,6 @@ function generate_loader_ksh() {
 		# Bootstrap EUPS
 		EUPS_DIR="\${LSST_HOME}/eups"
 		source "\${EUPS_DIR}/bin/setups.sh"
-		EUPS_PATH="\${LSST_HOME}"
 
 		# Setup optional packages
 		$CMD_SETUP_ANACONDA
@@ -417,7 +414,6 @@ function generate_loader_zsh() {
 		# Bootstrap EUPS
 		EUPS_DIR="\${LSST_HOME}/eups"
 		source "\${EUPS_DIR}/bin/setups.zsh"
-		EUPS_PATH="\${LSST_HOME}"
 
 		# Setup optional packages
 		$CMD_SETUP_ANACONDA


### PR DESCRIPTION
`loadLSST.*sh` currently resets the value of EUPS_PATH (which is set by the EUPS bootstrap script) to the value of LSST_HOME.

This prevents having multiple directories in EUPS_PATH and in particular prevents developing private packages on top of a read-only binary stack as
documented in [https://github.com/airnandez/lsst-cvmfs/blob/master/AdvancedUsage.md](https://github.com/airnandez/lsst-cvmfs/blob/master/AdvancedUsage.md)