### PR TITLE
replace hardcoded python interpreter by PYTHON variable

### DIFF
--- a/scripts/newinstall.sh
+++ b/scripts/newinstall.sh
@@ -166,7 +166,7 @@ fi
 ##########	Test/warn about Python versions, offer to get anaconda if too old
 
 if true; then
-	PYVEROK=$(python -c 'import sys; print("%i" % (sys.hexversion >= 0x02070000 and sys.hexversion < 0x03000000))')
+	PYVEROK=$($PYTHON -c 'import sys; print("%i" % (sys.hexversion >= 0x02070000 and sys.hexversion < 0x03000000))')
 	if [[ "$batch_flag" = true ]]; then
 		WITH_ANACONDA=1
 	else


### PR DESCRIPTION
`newinstall.sh` uses a fixed python interpreter even if the -P option is used to specify the path to python to install EUPS.