### PR TITLE
do not halt and catch fire when run under py2.6

### DIFF
--- a/scripts/newinstall.sh
+++ b/scripts/newinstall.sh
@@ -187,11 +187,12 @@ fi
 
 if true; then
 	# Check the version by running a small Python program (taken from the Python EUPS package)
+	# XXX this will break if python is not in $PATH
 	PYVEROK=$(python -c 'import sys
 minver2=7
 minver3=5
-vmaj = sys.version_info.major
-vmin = sys.version_info.minor
+vmaj = sys.version_info[0]
+vmin = sys.version_info[1]
 if (vmaj == 2 and vmin >= minver2) or (vmaj == 3 and vmin >= minver3):
     print(1)
 else:


### PR DESCRIPTION
When run under python 2.6, the script would exit with a non-zero exit
status and a minimal python stack trace.

    Traceback (most recent call last):
      File "<string>", line 4, in <module>
    AttributeError: 'tuple' object has no attribute 'major'

This was preventing the script functioning, even in batch mode,  on a
vanilla el6 host.