### PR TITLE
bump eups to 2.1.1

### DIFF
--- a/scripts/newinstall.sh
+++ b/scripts/newinstall.sh
@@ -25,7 +25,7 @@ set -e
 # Note to developers: change these when the EUPS version we use changes
 #
 
-EUPS_VERSION=${EUPS_VERSION:-2.0.2}
+EUPS_VERSION=${EUPS_VERSION:-2.1.1}
 
 EUPS_GITREV=${EUPS_GITREV:-""}
 EUPS_GITREPO=${EUPS_GITREPO:-"https://github.com/RobertLuptonTheGood/eups.git"}


### PR DESCRIPTION
This release fixes support for eups "tarball" binary packages.