### PR TITLE
fix fail function exiting with status 0

### DIFF
--- a/scripts/newinstall.sh
+++ b/scripts/newinstall.sh
@@ -57,7 +57,7 @@ print_error() {
 }
 
 fail() {
-	code=${2:1}
+	local code=${2:-1}
 	[[ -n $1 ]] && print_error "$1"
 	# shellcheck disable=SC2086
 	exit $code


### PR DESCRIPTION
The exit status code variable was not using the correct sh default value
syntax.