### PR TITLE
version [core] eups install path + product install paths

### DIFF
--- a/scripts/newinstall.sh
+++ b/scripts/newinstall.sh
@@ -119,6 +119,16 @@ eups_dir() {
 	echo "$(eups_base_dir)/$(eups_slug)"
 }
 
+#
+# version the eups product installation path using the *complete* python
+# environment
+#
+# XXX this will probably need to be extended to include the compiler used for
+# binary tarballs
+#
+eups_path() {
+	echo "${LSST_HOME}/stack/$(python_env_slug)"
+}
 
 parse_args() {
 	local OPTIND
@@ -651,7 +661,7 @@ install_eups() {
 
 		$cmd ./configure \
 			--prefix="$(eups_dir)" \
-			--with-eups="$LSST_HOME" \
+			--with-eups="$(eups_path)" \
 			--with-python="$EUPS_PYTHON"
 		$cmd make install
 	) > eupsbuild.log 2>&1 ; then

--- a/scripts/newinstall.sh
+++ b/scripts/newinstall.sh
@@ -97,6 +97,10 @@ miniconda_slug() {
 	echo "miniconda${LSST_PYTHON_VERSION}-${MINICONDA_VERSION}"
 }
 
+python_env_slug() {
+	echo "$(miniconda_slug)-${LSSTSW_REF}"
+}
+
 parse_args() {
 	local OPTIND
 	local opt
@@ -251,7 +255,8 @@ default_eups_pkgroot() {
 	local target_cc
 	declare -a roots
 
-	local pyslug="miniconda${LSST_PYTHON_VERSION}-${MINICONDA_VERSION}-${LSSTSW_REF}"
+	local pyslug
+	pyslug=$(python_env_slug)
 
 	# only probe system *IF* tarballs are desired
 	if [[ $use_tarballs == true ]]; then

--- a/scripts/newinstall.sh
+++ b/scripts/newinstall.sh
@@ -93,6 +93,10 @@ usage() {
 	)"
 }
 
+miniconda_slug() {
+	echo "miniconda${LSST_PYTHON_VERSION}-${MINICONDA_VERSION}"
+}
+
 parse_args() {
 	local OPTIND
 	local opt
@@ -532,8 +536,8 @@ else:
 }
 
 bootstrap_miniconda() {
-	local miniconda_slug="miniconda${LSST_PYTHON_VERSION}-${MINICONDA_VERSION}"
-	local miniconda_path="${LSST_HOME}/${miniconda_slug}"
+	local miniconda_path
+	miniconda_path="${LSST_HOME}/$(miniconda_slug)"
 
 	if [[ ! -e $miniconda_path ]]; then
 		miniconda::install \


### PR DESCRIPTION
* Similar to the current behavior of `lsst/lsstsw`, install eups under
`./eups/<version>` (Eg., `./eups/2.1.3`.) and symlink `./eups/current` to the
directory.

* Version the eups product install path with the "python environment". Eg.,
`./stack/miniconda3-4.2.12-7c8e67`  This will likely be needed in the future to
prevent linkage problems between binary tarballs packages built under different
python environments.