### PR TITLE
completely remove osx from travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: cpp
 os:
   - linux
-  - osx
+  #- osx
 # the default precise linux container has gcc 4.6
 sudo: required
 dist: trusty
@@ -43,8 +43,8 @@ env:
 matrix:
   # osx builds are often very slow to start due to high demand
   fast_finish: true
-  allow_failures:
-    - os: osx
+  #allow_failures:
+  #  - os: osx
   include:
     - os: linux
       env:


### PR DESCRIPTION
In hopes that this will improve travis build scheduling times.