### PR TITLE
do not preserve EUPS_PKGROOT by default

### DIFF
--- a/spec/unit/n8l/parse_args_spec.rb
+++ b/spec/unit/n8l/parse_args_spec.rb
@@ -4,20 +4,20 @@ describe 'n8l::parse_args' do
   include Rspec::Bash
 
   let(:stubbed_env) { create_stubbed_env }
+  subject(:func) { 'n8l::parse_args' }
 
   context 'cli options' do
     context 'without arguments' do
-      %w[b c n 2 3 t T s S].each do |flag|
+      %w[b c n 2 3 t T s S p].each do |flag|
         context "-#{flag}" do
           it 'should not die' do
             out, err, status = stubbed_env.execute_function(
               'scripts/newinstall.sh',
-              "n8l::parse_args -#{flag}",
+              "#{func} -#{flag}",
             )
 
             expect(out).to eq('')
             expect(err).to eq('')
-
             expect(status.exitstatus).to be 0
           end
         end # context "-#{flag}"
@@ -30,12 +30,11 @@ describe 'n8l::parse_args' do
           it 'should not die' do
             out, err, status = stubbed_env.execute_function(
               'scripts/newinstall.sh',
-              "n8l::parse_args -#{flag} foo",
+              "#{func} -#{flag} foo",
             )
 
             expect(out).to eq('')
             expect(err).to eq('')
-
             expect(status.exitstatus).to be 0
           end
         end # context "-#{flag}"
@@ -48,16 +47,49 @@ describe 'n8l::parse_args' do
           it 'should die' do
             out, err, status = stubbed_env.execute_function(
               'scripts/newinstall.sh',
-              "n8l::parse_args -#{flag}",
+              "#{func} -#{flag}",
             )
 
             expect(out).to eq('')
             expect(err).to match(/usage: newinstall.sh/)
-
             expect(status.exitstatus).to_not be 0
           end
         end # context "-#{flag}"
       end
     end # context '-h or unknown option'
+
+    context '-p' do
+      context 'unset' do
+        it 'should not set PRESERVE_EUPS_PKGROOT_FLAG' do
+          out, err, status = stubbed_env.execute_function(
+            'scripts/newinstall.sh',
+            <<-SCRIPT
+              #{func}
+              echo -n PRESERVE_EUPS_PKGROOT_FLAG=$PRESERVE_EUPS_PKGROOT_FLAG
+            SCRIPT
+          )
+
+          expect(out).to eq('PRESERVE_EUPS_PKGROOT_FLAG=')
+          expect(err).to eq('')
+          expect(status.exitstatus).to be 0
+        end
+      end
+
+      context 'set' do
+        it 'should set PRESERVE_EUPS_PKGROOT_FLAG=true' do
+          out, err, status = stubbed_env.execute_function(
+            'scripts/newinstall.sh',
+            <<-SCRIPT
+              #{func} -p
+              echo -n PRESERVE_EUPS_PKGROOT_FLAG=$PRESERVE_EUPS_PKGROOT_FLAG
+            SCRIPT
+          )
+
+          expect(out).to eq('PRESERVE_EUPS_PKGROOT_FLAG=true')
+          expect(err).to eq('')
+          expect(status.exitstatus).to be 0
+        end
+      end
+    end # context "-p"
   end # context 'cli options'
 end


### PR DESCRIPTION
in the loadLSST.* scripts.  A `-p` cli option is added to enable the
previous behavior of preserving EUPS_PKGROOT.