### PR TITLE
DM-14052: export eups shell function definitions

### DIFF
--- a/scripts/newinstall.sh
+++ b/scripts/newinstall.sh
@@ -906,6 +906,8 @@ n8l::generate_loader_bash() {
 		# Bootstrap EUPS
 		EUPS_DIR="\${LSST_HOME}/eups/$(n8l::eups_slug)"
 		source "\${EUPS_DIR}/bin/setups.sh"
+		export -f setup
+		export -f unsetup
 
 		export EUPS_PKGROOT=\${EUPS_PKGROOT:-$eups_pkgroot}
 	EOF


### PR DESCRIPTION
in loadLSST.bash. eups doesn't do this because it wants to be POSIXly
correct, but a script that is explicitly bash is a good place to do
this so our users can use setup and unsetup in their own scripts.