### PR TITLE
do not pass -u to fmt -- unsupported on osx

### DIFF
--- a/scripts/newinstall.sh
+++ b/scripts/newinstall.sh
@@ -122,7 +122,7 @@ n8l::require_cmds() {
 }
 
 n8l::fmt() {
-	fmt -uw 78
+	fmt -w 78
 }
 
 n8l::usage() {


### PR DESCRIPTION
The -u flag results in this error message on osx:

    fmt: illegal option -- u
    usage:   fmt [-cmps] [-d chars] [-l num] [-t num]
                 [-w width | -width | goal [maximum]] [file ...]
    Options: -c     center each line instead of formatting
             -d <chars> double-space after <chars> at line end
             -l <n> turn each <n> spaces at start of line into a tab
             -m     try to make sure mail header lines stay separate
             -n     format lines beginning with a dot
             -p     allow indented paragraphs
             -s     coalesce whitespace inside lines
             -t <n> have tabs every <n> columns
             -w <n> set maximum width to <n>
             goal   set target width to goal