### PR TITLE
always overwrite an existing link name

### DIFF
--- a/scripts/newinstall.sh
+++ b/scripts/newinstall.sh
@@ -74,7 +74,8 @@ n8l::fail() {
 }
 
 #
-# create/update a *relative* symlink, in the basedir of the target
+# create/update a *relative* symlink, in the basedir of the target. An existing
+# file or directory will be *stomped on*.
 #
 n8l::ln_rel() {
 	local link_target=${1?link target is required}
@@ -89,7 +90,7 @@ n8l::ln_rel() {
 		if [[ $(readlink "$target_name") != "$link_name" ]]; then
 			# at least "ln (GNU coreutils) 8.25" will not change an abs symlink to be
 			# rel, even with `-f`
-			rm -f "$link_name"
+			rm -rf "$link_name"
 			ln -sf "$target_name" "$link_name"
 		fi
 	)

--- a/spec/unit/n8l/ln_rel_spec.rb
+++ b/spec/unit/n8l/ln_rel_spec.rb
@@ -50,7 +50,7 @@ describe 'n8l::ln_rel' do
     expect(basename).to be_called_with_arguments('/dne/target').times(1)
     expect(cd).to be_called_with_arguments('/dne').times(1)
     expect(readlink).to be_called_with_arguments('target').times(1)
-    expect(rm).to be_called_with_arguments('-f', '/dne/name').times(1)
+    expect(rm).to be_called_with_arguments('-rf', '/dne/name').times(1)
     expect(ln).to be_called_with_arguments(
       '-sf', 'target', '/dne/name'
     ).times(1)


### PR DESCRIPTION
This is to allow recovery from an edge case failure mode seen under jenkins.
The scenario is that a previous run of `newinstall.sh` was killed part way
through an installation, before creating a `current` symlink for the
`EUPS_PATH`. Jenkins will then create the `EUPS_PATH` directory path,
constructed using `current` instead of the miniconda env slug, as a side effect
from attempting to clean up any log files from a previous build.