### PR TITLE
bump osx cc to clang-802.0.42

### DIFF
--- a/scripts/newinstall.sh
+++ b/scripts/newinstall.sh
@@ -318,7 +318,7 @@ n8l::sys::platform() {
 				# XXX bash 3.2 on osx does not support case fall-through
 				10.9.* | 10.1?.*)
 					__platform=10.9
-					__target_cc=clang-800.0.42.1
+					__target_cc=clang-802.0.42
 					;;
 				*)
 					[[ $__debug == true ]] && n8l::print_error "unsupported release: $__release"

--- a/scripts/newinstall.sh
+++ b/scripts/newinstall.sh
@@ -35,6 +35,14 @@ LSST_MINICONDA_BASE_URL=${LSST_MINICONDA_BASE_URL:-https://repo.continuum.io/min
 LSST_CONDA_CHANNELS=${LSST_CONDA_CHANNELS:-}
 LSST_CONDA_ENV_NAME=${LSST_CONDA_ENV_NAME:-lsst-scipipe-${LSST_LSSTSW_REF}}
 
+# these optional env vars may be used by functions but should be considered
+# unstable and for internal testing only.
+#
+# LSST_OS_FAMILY
+# LSST_OS_RELEASE
+# LSST_PLATFORM
+# LSST_COMPILER
+
 LSST_HOME="$PWD"
 
 # the canonical source of this script
@@ -362,9 +370,15 @@ n8l::default_eups_pkgroot() {
 		n8l::sys::osfamily osfamily release
 	fi
 
+	osfamily=${LSST_OS_FAMILY:-$osfamily}
+	release=${LSST_OS_RELEASE:-$release}
+
 	if [[ -n $osfamily && -n $release ]]; then
 		n8l::sys::platform "$osfamily" "$release" platform target_cc
 	fi
+
+	platform=${LSST_PLATFORM:-$platform}
+	target_cc=${LSST_COMPILER:-$target_cc}
 
 	if [[ -n $base_url ]]; then
 		if [[ -n $platform && -n $target_cc ]]; then

--- a/spec/unit/n8l/default_eups_pkgroot_spec.rb
+++ b/spec/unit/n8l/default_eups_pkgroot_spec.rb
@@ -43,4 +43,26 @@ describe 'n8l::default_eups_pkgroot' do
     expect(err).to eq('')
     expect(status.exitstatus).to be 0
   end
+
+  context 'use tarballs' do
+    it 'uses LSST_* env vars instead of "probed" values' do
+      # prevent probing for system info which might fail
+      stubbed_env.stub_command('n8l::sys::osfamily').returns_exitstatus(0)
+
+      out, err, status = stubbed_env.execute_function(
+        'scripts/newinstall.sh',
+        "#{func} false true",
+        {
+          'LSST_OS_FAMILY'  => 'redhat',
+          'LSST_OS_RELEASE' => '7',
+          'LSST_PLATFORM'   => 'el7',
+          'LSST_COMPILER'   => 'very-unlikely-string',
+        },
+      )
+
+      expect(out).to match(%(redhat/el7/very-unlikely-string))
+      expect(err).to eq('')
+      expect(status.exitstatus).to be 0
+    end
+  end
 end

--- a/spec/unit/n8l/sys/platform_spec.rb
+++ b/spec/unit/n8l/sys/platform_spec.rb
@@ -142,7 +142,7 @@ describe 'n8l::sys::platform' do
 
             expect(status.exitstatus).to be 0
             expect(out).to match(/PLATFORM=10.9/)
-            expect(out).to match(/TARGET_CC=clang-800.0.42.1/)
+            expect(out).to match(/TARGET_CC=clang-802.0.42/)
             expect(err).to eq('')
           end
         end


### PR DESCRIPTION
This is needed to switch from using the current SQRE osx 10.11 VM images to osx 10.12.