### PR TITLE
Use a conda install if it exists

### DIFF
--- a/scripts/newinstall.sh
+++ b/scripts/newinstall.sh
@@ -636,6 +636,9 @@ n8l::miniconda::bootstrap() {
 	if [[ -z $miniconda_path ]]; then
 		local miniconda_base_path="${prefix}/conda"
 		miniconda_path="${miniconda_base_path}/$(n8l::miniconda_slug)"
+	fi
+
+	if [[ ! -e $miniconda_path ]]; then
 		echo "Installing conda at ${miniconda_path}"
 		do_install=true
 	else

--- a/scripts/newinstall.sh
+++ b/scripts/newinstall.sh
@@ -626,8 +626,6 @@ n8l::miniconda::bootstrap() {
 	local splenv_ref=$6
 	local conda_channels=$7
 
-	local performed_install=false
-
 	# Clear arguments for source
 	while (( "$#" )); do
 		shift
@@ -644,17 +642,14 @@ n8l::miniconda::bootstrap() {
 				"$miniconda_base_url"
 			# only miniconda current symlink if we installed miniconda
 			n8l::ln_rel "$miniconda_path" current
-			performed_install=true
 		fi
 	fi
 
-	if [[ $performed_install == false ]]; then
-		(
-			export PATH="${miniconda_path}/bin:${PATH}"
-			n8l::require_cmds conda
-		)
-		echo "Using conda at ${miniconda_path}"
-	fi
+	(
+		export PATH="${miniconda_path}/bin:${PATH}"
+		n8l::require_cmds conda
+	)
+	echo "Using conda at ${miniconda_path}"
 
 	# Activate the base conda environment before continuing
 	# shellcheck disable=SC1090

--- a/scripts/newinstall.sh
+++ b/scripts/newinstall.sh
@@ -626,7 +626,7 @@ n8l::miniconda::bootstrap() {
 	local splenv_ref=$6
 	local conda_channels=$7
 
-	local do_install=false
+	local performed_install=false
 
 	# Clear arguments for source
 	while (( "$#" )); do
@@ -638,18 +638,17 @@ n8l::miniconda::bootstrap() {
 		miniconda_path="${miniconda_base_path}/$(n8l::miniconda_slug)"
 		if [[ ! -e $miniconda_path ]]; then
 			echo "Installing conda at ${miniconda_path}"
-			do_install=true
+			n8l::miniconda::install \
+				"$mini_ver" \
+				"$miniconda_path" \
+				"$miniconda_base_url"
+			# only miniconda current symlink if we installed miniconda
+			n8l::ln_rel "$miniconda_path" current
+			performed_install=true
 		fi
 	fi
 
-	if [[ $do_install == true ]]; then
-		n8l::miniconda::install \
-			"$mini_ver" \
-			"$miniconda_path" \
-			"$miniconda_base_url"
-		# only miniconda current symlink if we installed miniconda
-		n8l::ln_rel "$miniconda_path" current
-	else
+	if [[ $performed_install == false ]]; then
 		(
 			export PATH="${miniconda_path}/bin:${PATH}"
 			n8l::require_cmds conda

--- a/scripts/newinstall.sh
+++ b/scripts/newinstall.sh
@@ -639,7 +639,7 @@ n8l::miniconda::bootstrap() {
 		if [[ ! -e $miniconda_path ]]; then
 			echo "Installing conda at ${miniconda_path}"
 			do_install=true
-    fi
+		fi
 	fi
 
 	if [[ $do_install == true ]]; then
@@ -649,7 +649,7 @@ n8l::miniconda::bootstrap() {
 			"$miniconda_base_url"
 		# only miniconda current symlink if we installed miniconda
 		n8l::ln_rel "$miniconda_path" current
-  else
+	else
 		(
 			export PATH="${miniconda_path}/bin:${PATH}"
 			n8l::require_cmds conda
@@ -662,8 +662,8 @@ n8l::miniconda::bootstrap() {
 	source "$miniconda_path/bin/activate"
 
 	if [[ -e ${miniconda_path}/envs/${LSST_CONDA_ENV_NAME} ]]; then
-	  echo "An environment named ${LSST_CONDA_ENV_NAME} already exists"
-  fi
+		echo "An environment named ${LSST_CONDA_ENV_NAME} already exists"
+	fi
 
 	if [[ -n $splenv_ref ]]; then
 		n8l::miniconda::lsst_env "$splenv_ref" "$miniconda_path" "$conda_channels"

--- a/scripts/newinstall.sh
+++ b/scripts/newinstall.sh
@@ -636,18 +636,10 @@ n8l::miniconda::bootstrap() {
 	if [[ -z $miniconda_path ]]; then
 		local miniconda_base_path="${prefix}/conda"
 		miniconda_path="${miniconda_base_path}/$(n8l::miniconda_slug)"
-	fi
-
-	if [[ ! -e $miniconda_path ]]; then
-		echo "Installing conda at ${miniconda_path}"
-		do_install=true
-	else
-		# Check commands in supplied conda environment
-		(
-			export PATH="${miniconda_path}/bin:${PATH}"
-			n8l::require_cmds conda
-		)
-		echo "Using conda at ${miniconda_path}"
+		if [[ ! -e $miniconda_path ]]; then
+			echo "Installing conda at ${miniconda_path}"
+			do_install=true
+    fi
 	fi
 
 	if [[ $do_install == true ]]; then
@@ -657,6 +649,12 @@ n8l::miniconda::bootstrap() {
 			"$miniconda_base_url"
 		# only miniconda current symlink if we installed miniconda
 		n8l::ln_rel "$miniconda_path" current
+  else
+		(
+			export PATH="${miniconda_path}/bin:${PATH}"
+			n8l::require_cmds conda
+		)
+		echo "Using conda at ${miniconda_path}"
 	fi
 
 	# Activate the base conda environment before continuing


### PR DESCRIPTION
This precomputes a miniconda path and assumes it may exist and be valid. If it's valid, we go ahead and use it.