### PR TITLE
Introducing rubinenv

### DIFF
--- a/scripts/newinstall.sh
+++ b/scripts/newinstall.sh
@@ -497,7 +497,6 @@ n8l::miniconda::lsst_env() {
 		args+=("-c conda-forge")
 		args+=("rubin-env=${ref}")
 
-		echo "conda ${args[@]}"
 		$cmd conda "${args[@]}"
 		echo "Cleaning conda environment..."
 		conda clean -y -a > /dev/null
@@ -668,7 +667,7 @@ n8l::prepare_eups() {
 
 	# if there is an old eups installation, built from GitHub, renamed to "legacy"
 	if [[ -e "$(n8l::eups_dir)/Release_Notes" ]]; then
-		if [ ! -d "${LSSTSW_HOME}/eups-legacy" ]; then
+		if [ ! -d "${LSST_HOME}/eups-legacy" ]; then
 			mv "$(n8l::eups_base_dir)" "${LSST_HOME}/eups-legacy"
 		else
 			echo "Found eups-legacy, remove it before moving old eups to legacy"
@@ -730,7 +729,8 @@ n8l::generate_loader_bash() {
 	local eups_pkgroot=${2?eups_pkgroot is required}
 	local miniconda_path=$3
 
-	local eups_path="$(n8l::eups_path)"
+	local eups_path
+	eups_path="$(n8l::eups_path)"
 
 	if [[ -n $miniconda_path ]]; then
 		local cmd_setup_miniconda
@@ -762,7 +762,8 @@ n8l::generate_loader_ksh() {
 	local eups_pkgroot=${2?eups_pkgroot is required}
 	local miniconda_path=$3
 
-	local eups_path="$(n8l::eups_path)"
+	local eups_path
+	eups_path="$(n8l::eups_path)"
 
 	if [[ -n $miniconda_path ]]; then
 		# XXX untested
@@ -794,7 +795,8 @@ n8l::generate_loader_zsh() {
 	local eups_pkgroot=${2?eups_pkgroot is required}
 	local miniconda_path=$3
 
-	local eups_path="$(n8l::eups_path)"
+	local eups_path
+	eups_path="$(n8l::eups_path)"
 
 	if [[ -n $miniconda_path ]]; then
 		# XXX untested
@@ -953,7 +955,7 @@ n8l::main() {
 
 	# Use conda base environment's python
 	# shellcheck disable=SC2153
-	EUPS_PYTHON=${MINICONDA_PATH}/bin/python
+	export EUPS_PYTHON=${MINICONDA_PATH}/bin/python
 
 	if [[ $PRESERVE_EUPS_PKGROOT_FLAG == true ]]; then
 		EUPS_PKGROOT=${EUPS_PKGROOT:-$(

--- a/scripts/newinstall.sh
+++ b/scripts/newinstall.sh
@@ -28,7 +28,7 @@ LSST_EUPS_USE_EUPSPKG=${LSST_EUPS_USE_EUPSPKG:-true}
 LSST_MINICONDA_VERSION=${LSST_MINICONDA_VERSION:-py37_4.8.2}
 # this git ref controls which set of conda packages are used to initialize the
 # the default conda env defined in scipipe_conda_env git package (RFC-553).
-LSST_SPLENV_REF=${LSST_SPLENV_REF:-${LSST_LSSTSW_REF:-0.1.0}}
+LSST_SPLENV_REF=${LSST_SPLENV_REF:-${LSST_LSSTSW_REF:-0.1.5}}
 LSST_MINICONDA_BASE_URL=${LSST_MINICONDA_BASE_URL:-https://repo.continuum.io/miniconda}
 LSST_CONDA_CHANNELS=${LSST_CONDA_CHANNELS:-"conda-forge"}
 LSST_CONDA_ENV_NAME=${LSST_CONDA_ENV_NAME:-lsst-scipipe-${LSST_SPLENV_REF}}
@@ -496,7 +496,7 @@ n8l::miniconda::lsst_env() {
 		fi
 
 		args+=("-c conda-forge")
-		args+=("rubinenv=${ref}")
+		args+=("rubin-env=${ref}")
 
 		echo "conda ${args[@]}"
 		$cmd conda "${args[@]}"

--- a/scripts/newinstall.sh
+++ b/scripts/newinstall.sh
@@ -668,7 +668,11 @@ n8l::prepare_eups() {
 
 	# if there is an old eups installation, built from GitHub, renamed to "legacy"
 	if [[ -e "$(n8l::eups_dir)/Release_Notes" ]]; then
-		mv "$(n8l::eups_base_dir)" "${LSST_HOME}/eups-legacy"
+		if [ ! -d "${LSSTSW_HOME}/eups-legacy" ]; then
+			mv "$(n8l::eups_base_dir)" "${LSST_HOME}/eups-legacy"
+		else
+			echo "Found eups-legacy, remove it before moving old eups to legacy"
+		fi
 	fi
 
 	# create eups_path and subfolders
@@ -748,7 +752,7 @@ n8l::generate_loader_bash() {
 		${cmd_setup_miniconda}
 		LSST_HOME="\$( cd "\$( dirname "\${BASH_SOURCE[0]}" )" && pwd )"
 
-		export EUPS_PATH=$eups_path
+		export EUPS_PATH="$eups_path"
 		export EUPS_PKGROOT=\${EUPS_PKGROOT:-$eups_pkgroot}
 	EOF
 }
@@ -781,7 +785,7 @@ n8l::generate_loader_ksh() {
 		LSST_HOME="\$( cd "\$( dirname "\${.sh.file}" )" && pwd )"
 
 		export EUPS_PKGROOT=\${EUPS_PKGROOT:-$eups_pkgroot}
-		export EUPS_PATH=$eups_path
+		export EUPS_PATH="$eups_path"
 	EOF
 }
 
@@ -811,7 +815,7 @@ n8l::generate_loader_zsh() {
 		${cmd_setup_miniconda}
 		LSST_HOME=\`dirname "\$0:A"\`
 
-		export EUPS_PATH=$eups_path
+		export EUPS_PATH="$eups_path"
 		export EUPS_PKGROOT=\${EUPS_PKGROOT:-$eups_pkgroot}
 	EOF
 }

--- a/scripts/newinstall.sh
+++ b/scripts/newinstall.sh
@@ -25,7 +25,7 @@ LSST_EUPS_PKGROOT_BASE_URL=${LSST_EUPS_PKGROOT_BASE_URL:-https://eups.lsst.codes
 LSST_EUPS_USE_TARBALLS=${LSST_EUPS_USE_TARBALLS:-false}
 LSST_EUPS_USE_EUPSPKG=${LSST_EUPS_USE_EUPSPKG:-true}
 
-LSST_MINICONDA_VERSION=${LSST_MINICONDA_VERSION:-py37_4.8.2}
+LSST_MINICONDA_VERSION=${LSST_MINICONDA_VERSION:-py38_4.9.2}
 # this git ref controls which set of conda packages are used to initialize the
 # the default conda env defined in scipipe_conda_env git package (RFC-553).
 LSST_SPLENV_REF=${LSST_SPLENV_REF:-${LSST_LSSTSW_REF:-0.1.5}}


### PR DESCRIPTION
Changed to use rubin-env version instead of scipipe-conda-env SHA1.

Changed miniconda version from py37.4.8.2 to py38.4.9.2.

