### PR TITLE
Remove csh from newinstall.

### DIFF
--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -32,7 +32,6 @@ jobs:
   centos-matrix:
     strategy:
       matrix:
-        shell: [bash, csh]
         option: [-bt, -b]
     name: Linux installation test
     runs-on: ubuntu-latest
@@ -44,14 +43,8 @@ jobs:
           mkdir stack
           cd stack
           bash ../scripts/newinstall.sh ${{ matrix.option }}
-          if [[ "${{ matrix.shell }}" == "csh" ]]; then
-            yum install -y tcsh
-            shellcmd=tcsh
-          else
-            shellcmd=bash
-          fi
-          $shellcmd -c \
-            "source loadLSST.${{ matrix.shell }} && \
+          bash -c \
+            "source loadLSST.bash && \
              eups distrib install -t w_latest base"
 
   accept-interactive:

--- a/scripts/newinstall.sh
+++ b/scripts/newinstall.sh
@@ -828,43 +828,6 @@ n8l::generate_loader_bash() {
 	EOF
 }
 
-n8l::generate_loader_csh() {
-	local file_name=${1?file_name is required}
-	local eups_pkgroot=${2?eups_pkgroot is required}
-	local miniconda_path=$3
-
-	if [[ -n $miniconda_path ]]; then
-		local cmd_setup_miniconda
-		cmd_setup_miniconda="$(cat <<-EOF
-				if ( ! \$?LSST_CONDA_ENV_NAME ) then
-					set LSST_CONDA_ENV_NAME="${LSST_CONDA_ENV_NAME}"
-				endif
-				source "${miniconda_path}/etc/profile.d/conda.csh"
-				conda activate "\$LSST_CONDA_ENV_NAME"
-			EOF
-		)"
-	fi
-
-	# shellcheck disable=SC2094
-	cat > "$file_name" <<-EOF
-		# This script is intended to be used with (t)csh to load the minimal LSST
-		# environment
-		# Usage: source $(basename "$file_name")
-
-		${cmd_setup_miniconda}
-		set LSST_HOME = \`dirname \$0\`
-		set LSST_HOME = \`cd \${LSST_HOME} && pwd\`
-
-		# Bootstrap EUPS
-		set EUPS_DIR = "\${LSST_HOME}/eups/$(n8l::eups_slug)"
-		source "\${EUPS_DIR}/bin/setups.csh"
-
-		if ( ! \${?EUPS_PKGROOT} ) then
-		  setenv EUPS_PKGROOT "$eups_pkgroot"
-		endif
-	EOF
-}
-
 n8l::generate_loader_ksh() {
 	local file_name=${1?file_name is required}
 	local eups_pkgroot=${2?eups_pkgroot is required}
@@ -935,7 +898,7 @@ n8l::create_load_scripts() {
 	local eups_pkgroot=${2?eups_pkgroot is required}
 	local miniconda_path=$3
 
-	for sfx in bash ksh csh zsh; do
+	for sfx in bash ksh zsh; do
 		echo -n "Creating startup scripts (${sfx}) ... "
 		# shellcheck disable=SC2086
 		n8l::generate_loader_$sfx \
@@ -953,7 +916,6 @@ n8l::print_greeting() {
 		one of:
 
 			source "${LSST_HOME}/loadLSST.bash"  # for bash
-			source "${LSST_HOME}/loadLSST.csh"   # for csh
 			source "${LSST_HOME}/loadLSST.ksh"   # for ksh
 			source "${LSST_HOME}/loadLSST.zsh"   # for zsh
 


### PR DESCRIPTION
Since it has been broken for a long time and fails its test, I'm removing both the test and the writing of loadLSST.csh.

It doesn't look like it's impossible to fix it, so it may be resurrected at some time in the future.