### PR TITLE
Allow installing to a conda env by path not name

### DIFF
--- a/scripts/lsstinstall
+++ b/scripts/lsstinstall
@@ -74,7 +74,7 @@ EOF
     exit 1
 }
 
-while getopts nBST:X:v:e:udp:PC:E:bcth opt; do
+while getopts nBST:X:v:e:audp:PC:E:bcth opt; do
     case "$opt" in
         n)
             dryrun="echo \$ "


### PR DESCRIPTION
Currently the `lsstinstall` script always creates a conda environment using the `-n` flag which specifies an environment by name. This is usually either in a central location or in the user's home directory.  On some systems (like NERSC) neither of these is suitable, and many people (e.g. me) prefer to have environment directories alongside their working directory. 

This adds a flag that makes conda use the `-p` flag to specify a path instead of `-n` for a name for the new (or updated) conda environment. I picked the flag `-b` (update: now `-a`) pretty randomly (for "by") but if there's some other choice that would be more consistent with LSST patterns let me know.